### PR TITLE
Removed duplicated Delete buttons when listing form entries

### DIFF
--- a/tendenci2018/templates/forms/entries.html
+++ b/tendenci2018/templates/forms/entries.html
@@ -43,7 +43,8 @@
             &nbsp;&ndash;&nbsp;{% blocktrans with n=field.value|basename %}{{ n }}{% endblocktrans %}
             {% else %}
             &nbsp;&ndash;&nbsp;{% blocktrans with v=field.value|truncatewords:"2" %}{{ v }}{% endblocktrans %}
-            <br /><br />
+            {% endif %}
+            {% endfor %}
           </a>
         </li>
         
@@ -56,8 +57,6 @@
           </div>
         </li>
         
-        {% endif %}
-        {% endfor %}
         
       </ul>
     </div>


### PR DESCRIPTION
How to reproduce the issue:

- Log in as an admin in the demo site and go to https://demo.tendenci.com/forms/entries/1
- Multiple Delete buttons are displayed for each form entry (one button for each form field)

This PR fixes the nesting of the `endif` and `endfor` tags based on the [entries.html](https://github.com/tendenci/tendenci/blob/master/tendenci/apps/forms_builder/forms/templates/forms/entries.html#L30-L40) template.