### PR TITLE
Fixed sidebar display in event search view

### DIFF
--- a/tendenci2018/templates/events/meta.html
+++ b/tendenci2018/templates/events/meta.html
@@ -47,7 +47,6 @@
       </li>
       {% endif %}
       
-      {% endif %}
       
       <div style="clear:both;"></div>
     </ul>
@@ -92,6 +91,7 @@
         </ul>
       </li>
     </ul>
+    {% endif %}
     
   </div>
 </nav>


### PR DESCRIPTION
How to reproduce the issue:

Go to the event search view: https://demo.tendenci.com/events/search/ as:

* Anonymous user. The sidebar displays correctly.
* Administrator. The sidebar displays correctly.
* Common user (that can't edit events). The sidebar breaks like this:

![captura de pantalla de 2018-04-12 12-03-14](https://user-images.githubusercontent.com/560781/38695470-9849b6dc-3e49-11e8-819b-ebffa18bd643.png)

This PR fixes a misplaced `{% endif %}` tag that causes the problem.
