### PR TITLE
remove self groups fixed

### DIFF
--- a/tendenci2018/templates/user_groups/detail.html
+++ b/tendenci2018/templates/user_groups/detail.html
@@ -62,7 +62,7 @@
           {% blocktrans %}Users cannot add themselves to this group{% endblocktrans %}</a></li>
         {% endif %}
         
-        {% if group.allow_self.remove %}
+        {% if group.allow_self_remove %}
         <li><a href="{% url "group.edit" group.slug %}">
           {% blocktrans %}Users can remove themselves from this group{% endblocktrans %}</a></li>
         {% else %}


### PR DESCRIPTION
Hello, it's me again, I took the time to check this and I found the same issue for **"remove themsleves from groups"** 

Pull request related with: https://github.com/tendenci/tendenci/pull/744

I've changed it here too.

Lines changed: 
```jinja
{% if group.allow_self.remove %}
```
to
```jinja
{% if group.allow_self_remove %}
```